### PR TITLE
Update snapcraft SPI Part

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -175,9 +175,9 @@ slots:
   bt-serial:
     interface: serial-port
     path: /dev/ttyAMA0
-  spidev0.0:
+  spidev0:
      interface: spi
      path: /dev/spidev0.0
-  spidev0.1:
+  spidev1:
      interface: spi
      path: /dev/spidev0.1


### PR DESCRIPTION
It shows me when I install the edge gadget invalid plugs and slots for SPI I adjust the names, l hope its working now.